### PR TITLE
build: move common dependency versions to root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ allprojects {
 }
 
 subprojects {
+	ext {
+		junitJupiterApi = "5.7.2"
+	}
 	apply plugin: "java-library"
 	apply plugin: "signing"
 	apply plugin: "maven-publish"

--- a/buildSrc/src/main/groovy/java-library-convention.gradle
+++ b/buildSrc/src/main/groovy/java-library-convention.gradle
@@ -7,11 +7,6 @@ plugins {
 
 def isLocalDevEnv = (System.getenv("CI") == null)
 
-dependencies {
-	//testImplementation("nl.jqno.equalsverifier:equalsverifier:3.7.1")
-	testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
-	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-}
 configurations.all {
 	resolutionStrategy {
 		failOnVersionConflict()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,3 +2,8 @@ plugins {
 	id "java-library-convention"
 }
 description = "Common Java Utilities"
+
+dependencies {
+	testImplementation("org.junit.jupiter:junit-jupiter-api:${junitJupiterApi}")
+	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}


### PR DESCRIPTION
Dependabot doesn't seem to pick up updates to dependencies under `buildSrc` directory.  Define dependencies per project `build.gradle`, but define version variables in the root `build.gradle` for shared dependencies.